### PR TITLE
Go 1.13 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Inspired by https://github.com/mumoshu/dcind
-FROM golang:latest
+FROM golang:1.13
 MAINTAINER Francesco Farina <rockerg991@gmail.com>
 
-ENV DOCKER_VERSION=17.09.1~ce-0~debian \
+ENV DOCKER_VERSION=17.12.0~ce-0~debian \
     DOCKER_COMPOSE_VERSION=1.18.0 \
     ENTRYKIT_VERSION=0.4.0
 
@@ -19,8 +19,7 @@ RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
 RUN apt-get update && apt-cache policy docker-ce && apt-get install -y docker-ce=${DOCKER_VERSION} --allow-unauthenticated && \
     pip install docker-compose==${DOCKER_COMPOSE_VERSION}
 
-RUN go get -u github.com/golang/dep/cmd/dep && \
-    (cd /usr/local; wget -O - -q https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s latest)
+RUN (cd /usr/local; wget -O - -q https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s latest)
 
 # Install entrykit
 RUN curl -L https://github.com/progrium/entrykit/releases/download/v${ENTRYKIT_VERSION}/entrykit_${ENTRYKIT_VERSION}_Linux_x86_64.tgz | tar zx && \
@@ -33,8 +32,8 @@ RUN curl -L https://github.com/progrium/entrykit/releases/download/v${ENTRYKIT_V
 COPY docker-lib.sh /docker-lib.sh
 
 ENTRYPOINT [ \
-	"switch", \
-		"shell=/bin/sh", "--", \
-	"codep", \
-		"/usr/bin/dockerd" \
-]
+    "switch", \
+    "shell=/bin/sh", "--", \
+    "codep", \
+    "/usr/bin/dockerd" \
+    ]


### PR DESCRIPTION
 - Updated base golang image to 1.13
 - Updated Docker version to `17.12.0`
 - Removed dep in favour of modules